### PR TITLE
Fix ZThunk impl of `DecompressPtrToDstArray`

### DIFF
--- a/pdCompressZThunk.cls
+++ b/pdCompressZThunk.cls
@@ -288,7 +288,7 @@ Private Function ICompress_DecompressPtrToDstArray( _
     If (Not dstArrayIsAlreadySized) Then
         ReDim dstArray(0 To constDstSizeInBytes - 1) As Byte
     End If
-    If Not ICompress_CompressPtrToPtr(VarPtr(dstArray(0)), constDstSizeInBytes, _
+    If Not ICompress_DecompressPtrToPtr(VarPtr(dstArray(0)), constDstSizeInBytes, _
             constSrcPtr, constSrcSizeInBytes) Then
         GoTo QH
     End If


### PR DESCRIPTION
Obviously `DecompressPtrToDstArray` is not being used by the test harness, still. . . the bug is blatant